### PR TITLE
フォロー機能のための中間テーブルusers_users作成＆多対多のリレーション実装

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -36,4 +36,16 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+    
+    //このユーザーがフォローしている人を取得
+    public function follows()
+    {
+        return $this->belongsToMany(User::class, 'users_users', 'following_id', 'followed_id')->withTimestamps();    
+    }
+    
+    //このユーザーをフォローしている人を取得
+    public function followers()
+    {
+        return $this->belongsToMany(User::class, 'users_users', 'followed_id', 'following_id')->withTimestamps();    
+    }
 }

--- a/database/migrations/2022_07_09_215235_create_users_users_table.php
+++ b/database/migrations/2022_07_09_215235_create_users_users_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateUsersUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users_users', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('following_id');//フォローする人
+            $table->unsignedBigInteger('followed_id');//フォローされる人
+            $table->timestamps();
+            
+            //外部キー制約
+            $table->foreign('following_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('followed_id')->references('id')->on('users')->onDelete('cascade');
+            
+            //following_idとfollowed_idの組み合わせの重複を許さない
+            $table->unique(['following_id', 'followed_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users_users');
+    }
+}


### PR DESCRIPTION
フォロー機能のための中間テーブルusers_users作成＆多対多のリレーション実装しました。userモデルでリレーションを実装し、follows()でユーザーがフォローしている人を取得、followers()でユーザーをフォローしている人、フォロワーを取得できるようにしました。